### PR TITLE
Volume needs escaping

### DIFF
--- a/rclone-mount/Dockerfile
+++ b/rclone-mount/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache --update alpine-sdk ca-certificates go git fuse fuse-dev 
 ADD start.sh /start.sh
 RUN chmod +x /start.sh 
 
-VOLUME [$AccessFolder]
+VOLUME ["$AccessFolder"]
 
 CMD ["/start.sh"]
 


### PR DESCRIPTION
https://docs.docker.com/engine/reference/builder/#volume
Currently causes a /[/mnt] directory to be created on boot