### PR TITLE
Changed default route lookup commands

### DIFF
--- a/sabnzbdvpn/openvpn/start.sh
+++ b/sabnzbdvpn/openvpn/start.sh
@@ -16,7 +16,7 @@
 
 #set routing gateway for the container
 if [ -n "${LOCAL_NETWORK-}" ]; then
-  eval $(/sbin/ip r l m 0.0.0.0 | awk '{if($5!="tun0"){print "GW="$3"\nINT="$5; exit}}')
+  eval $(/sbin/ip r s 0.0.0.0/0 | awk '{if($5!="tun0"){print "GW="$3"\nINT="$5; exit}}')
   if [ -n "${GW-}" -a -n "${INT-}" ]; then
     echo "adding route to local network $LOCAL_NETWORK via $GW dev $INT"
     /sbin/ip r a "$LOCAL_NETWORK" via "$GW" dev "$INT"


### PR DESCRIPTION
`/sbin/ip r l m 0.0.0.0` was returning a error regarding the route metric and was not returning anything for the following statements leaving out the creation of the local default route. I changes to the `ip route show with the default route out (ip r s 0.0.0.0/0)` and it seems to have worked with a few tests.