### PR TITLE
Adding arm support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,7 @@ docker_build_repo1:
   - echo "$CI_PROJECT_PATH"
   - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
   - docker pull $REGPATH/$REPO1:$CI_COMMIT_REF_SLUG || true
-  - docker buildx build --push -t $REGPATH/$REPO1:$CI_COMMIT_SHA -t $REGPATH/$REPO1:$CI_COMMIT_REF_SLUG --platform linux/amd64,linux/arm/v7 --build-arg OVERLAY_ARCH=$TARGETARCH ./$REPO1
+  - docker buildx build --push -t $REGPATH/$REPO1:$CI_COMMIT_SHA -t $REGPATH/$REPO1:$CI_COMMIT_REF_SLUG --platform linux/amd64,linux/arm/v7 ./$REPO1
   only:
     refs:
       - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,18 +20,37 @@ before_script:
   - docker info
   #- docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
 
+buildx:
+  image: docker:19.03-git
+  stage: buildx
+  variables:
+    GIT_STRATEGY: none
+  artifacts:
+    paths:
+      - buildx
+    expire_in: 1 hour
+  services:
+    - docker:19.03-dind
+  script:
+    - export DOCKER_BUILDKIT=1
+    - git clone git://github.com/docker/buildx ./docker-buildx
+    - docker build --platform=local -o . ./docker-buildx
+
 docker_build_repo1:
   stage: build
   image: docker:latest
   services:
-  - docker:dind
+    - name: docker:19.03-dind
+      command: ["--experimental"]
+  before_script:
+    - mkdir -p ~/.docker/cli-plugins
+    - mv buildx ~/.docker/cli-plugins/docker-buildx
+    - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   script:
   - echo "$CI_PROJECT_PATH"
   - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
   - docker pull $REGPATH/$REPO1:$CI_COMMIT_REF_SLUG || true
-  - docker build --pull -t $REGPATH/$REPO1:$CI_COMMIT_SHA -t $REGPATH/$REPO1:$CI_COMMIT_REF_SLUG ./$REPO1
-  - docker push $REGPATH/$REPO1:$CI_COMMIT_SHA
-  - docker push $REGPATH/$REPO1:$CI_COMMIT_REF_SLUG
+  - docker buildx build --push -t $REGPATH/$REPO1:$CI_COMMIT_SHA -t $REGPATH/$REPO1:$CI_COMMIT_REF_SLUG --platform linux/amd64,linux/arm/v7 --build-arg OVERLAY_ARCH=$TARGETARCH ./$REPO1
   only:
     refs:
       - master

--- a/rclone-mount/Dockerfile
+++ b/rclone-mount/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:latest
+FROM alpine:3.12.0
 
 ARG OVERLAY_VERSION="v1.22.1.0"
-ARG OVERLAY_ARCH="amd64"
+ARG TARGETARCH
 
 ENV DEBUG="false" \
     GOPATH="/go" \
@@ -18,9 +18,9 @@ RUN apk --no-cache upgrade \
     && apk add --no-cache --update alpine-sdk ca-certificates go git fuse fuse-dev gnupg \
     && echo "Installing S6 Overlay" \
     && curl -o /tmp/s6-overlay.tar.gz -L \
-    "https://github.com/just-containers/s6-overlay/releases/download/${OVERLAY_VERSION}/s6-overlay-${OVERLAY_ARCH}.tar.gz" \
+    "https://github.com/just-containers/s6-overlay/releases/download/${OVERLAY_VERSION}/s6-overlay-${TARGETARCH}.tar.gz" \
     && curl -o /tmp/s6-overlay.tar.gz.sig -L \
-    "https://github.com/just-containers/s6-overlay/releases/download/${OVERLAY_VERSION}/s6-overlay-${OVERLAY_ARCH}.tar.gz.sig" \
+    "https://github.com/just-containers/s6-overlay/releases/download/${OVERLAY_VERSION}/s6-overlay-${TARGETARCH}.tar.gz.sig" \
     && curl https://keybase.io/justcontainers/key.asc | gpg --import \
     && gpg --verify /tmp/s6-overlay.tar.gz.sig /tmp/s6-overlay.tar.gz \
     && tar xfz /tmp/s6-overlay.tar.gz -C / \


### PR DESCRIPTION
Hello! Thanks for these images, they work great. I've been using this on a raspberry pi. This small change allows gitlab to create the images for both architectures. I tested it manually and it works fine:

`docker buildx build --push -t pablokbs/rclone-mount:latest --platform linux/amd64,linux/arm/v7  rclone-mount/`

![image](https://user-images.githubusercontent.com/4028336/84831446-b49f0e00-b001-11ea-9994-7e3f14c90bba.png)

I don't have a gitlab instance to test it, but I ran the steps on my computer and they seem to work.