### PR TITLE
Only copy the rclone executable file to the final image

### DIFF
--- a/rclone-mount/Dockerfile
+++ b/rclone-mount/Dockerfile
@@ -37,7 +37,7 @@ ENV DEBUG="false" \
     MountCommands="--allow-other --allow-non-empty" \
     UnmountCommands="-u -z"
 
-COPY --from=builder /go/src/github.com/rclone/rclone/rclone /usr/local/sbin/
+COPY --from=builder /go/src/github.com/rclone/rclone/rclone/rclone /usr/local/sbin/
 
 RUN apk --no-cache upgrade \
     && apk add --no-cache --update ca-certificates fuse fuse-dev curl gnupg \


### PR DESCRIPTION
Previously it copy a large folder with many unnecessary files, even including a 170+MB .git folder which makes the whole image 3x larger